### PR TITLE
Rails 5.2.1.1 compatibility - update ActiveStorage::Service#upload to handle service metadata

### DIFF
--- a/lib/active_storage/service/postgresql_service.rb
+++ b/lib/active_storage/service/postgresql_service.rb
@@ -64,17 +64,23 @@ module ActiveStorage
 
     def url(key, expires_in:, filename:, disposition:, content_type:)
       instrument :url, key: key do |payload|
-        verified_key_with_expiration = ActiveStorage.verifier.generate(key, expires_in: expires_in, purpose: :blob_key)
-
-        generated_url =
-          url_helpers.rails_disk_service_url(
-            verified_key_with_expiration,
-            host: current_host,
-            filename: filename,
-            disposition: content_disposition_with(type: disposition, filename: filename),
+        content_disposition = content_disposition_with(type: disposition, filename: filename)
+        verified_key_with_expiration = ActiveStorage.verifier.generate(
+          {
+            key: key,
+            disposition: content_disposition,
             content_type: content_type
-          )
+          },
+          { expires_in: expires_in,
+          purpose: :blob_key }
+        )
 
+        generated_url = url_helpers.rails_disk_service_url(verified_key_with_expiration,
+          host: current_host,
+          disposition: content_disposition,
+          content_type: content_type,
+          filename: filename
+        )
         payload[:url] = generated_url
 
         generated_url

--- a/lib/active_storage/service/postgresql_service.rb
+++ b/lib/active_storage/service/postgresql_service.rb
@@ -9,7 +9,7 @@ module ActiveStorage
     def initialize(**options)
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
         ActiveStorage::PostgreSQL::File.create!(key: key, io: io, checksum: checksum)
       end

--- a/test/active_storage/postgresql_test.rb
+++ b/test/active_storage/postgresql_test.rb
@@ -15,6 +15,17 @@ class ActiveStorage::Service::PostgreSQLServiceTest < ActiveSupport::TestCase
 
   include ActiveStorage::Service::SharedServiceTests
 
+  test "uploading with service metadata" do
+    begin
+      key  = SecureRandom.base58(24)
+      data = "Something else entirely!"
+      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), irrelevant_metadata: "ignored")
+      assert_equal data, @service.download(key)
+    ensure
+      @service.delete key
+    end
+  end
+
   test "uploading file with integrity" do
     begin
       key  = SecureRandom.base58(24)


### PR DESCRIPTION
Rails 5.2.1.1 was released which fixed a couple of security issues. One of which was [CVE-2018-16477](https://groups.google.com/forum/#!msg/rubyonrails-security/3KQRnXDIuLg/mByx5KkqBAAJ).

This change broke `active_storage-postgres` compatibility with Rails ~> 5.2 by adding passing optional service metadata keyword arguments to `ActiveStorage::Service#upload`. 

This PR adds the ability to receive service metadata in `#upload`, but ignores it.

I've also updated `ActiveStorage::Service::PostgreSQLService#url` with the fix for CVE-2018-16477 that was applied to `ActiveStorage::DiskService` in https://github.com/rails/rails/commit/54ed6ad8d7468dc3a0b690e629c7c18497552eb8. Happy to split this into a separate PR if required.