### PR TITLE
Postgresql controller

### DIFF
--- a/app/controllers/active_storage/postgresql_controller.rb
+++ b/app/controllers/active_storage/postgresql_controller.rb
@@ -17,7 +17,6 @@ class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
 
       ranges = Rack::Utils.get_byte_ranges(request.get_header('HTTP_RANGE'), size)
 
-
       if ranges.nil? || ranges.length > 1
         # # No ranges, or multiple ranges (which we don't support):
         # # TODO: Support multiple byte-ranges
@@ -25,16 +24,12 @@ class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
         range = 0..size-1
 
       elsif ranges.empty?
-        # # Unsatisfiable. Return error, and file size:
-        # response = fail(416, "Byte range unsatisfiable")
-        # response[1]["Content-Range"] = "bytes */#{size}"
-        # return response
+        head 416, content_range: "bytes */#{size}"
+        return
       else
-        # # Partial content:
         range = ranges[0]
         self.status = :partial_content
         response.headers["Content-Range"] = "bytes #{range.begin}-#{range.end}/#{size}"
-        # size = range.end - range.begin + 1
       end
       self.response_body = postgresql_service.download_chunk(key[:key], range)
     else

--- a/app/controllers/active_storage/postgresql_controller.rb
+++ b/app/controllers/active_storage/postgresql_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Serves files stored with the disk service in the same way that the cloud services do.
+# This means using expiring, signed URLs that are meant for immediate access, not permanent linking.
+# Always go through the BlobsController, or your own authenticated controller, rather than directly
+# to the service url.
+class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
+  include ActionController::Live
+
+  skip_forgery_protection
+
+  def show
+    if key = decode_verified_key
+      response.headers["Content-Type"] = params[:content_type] || DEFAULT_SEND_FILE_TYPE
+      response.headers["Content-Disposition"] = params[:disposition] || DEFAULT_SEND_FILE_DISPOSITION
+      postgresql_service.download key[:key] do |chunk|
+        response.stream.write chunk
+      end
+    else
+      head :not_found
+    end
+  ensure
+    response.stream.close
+  end
+
+  def update
+    if token = decode_verified_token
+      if acceptable_content?(token)
+        postgresql_service.upload token[:key], request.body, checksum: token[:checksum]
+        head :no_content
+      else
+        head :unprocessable_entity
+      end
+    end
+  rescue ActiveStorage::IntegrityError
+    head :unprocessable_entity
+  ensure
+    response.stream.close
+  end
+
+  private
+    def postgresql_service
+      ActiveStorage::Blob.service
+    end
+
+
+    def decode_verified_key
+      ActiveStorage.verifier.verified(params[:encoded_key], purpose: :blob_key)
+    end
+
+
+    def decode_verified_token
+      ActiveStorage.verifier.verified(params[:encoded_token], purpose: :blob_token)
+    end
+
+    def acceptable_content?(token)
+      token[:content_type] == request.content_mime_type && token[:content_length] == request.content_length
+    end
+end

--- a/app/controllers/active_storage/postgresql_controller.rb
+++ b/app/controllers/active_storage/postgresql_controller.rb
@@ -4,6 +4,7 @@
 # This means using expiring, signed URLs that are meant for immediate access, not permanent linking.
 # Always go through the BlobsController, or your own authenticated controller, rather than directly
 # to the service url.
+
 class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
   include ActionController::Live
 
@@ -31,6 +32,8 @@ class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
       else
         head :unprocessable_entity
       end
+    else
+      head :not_found
     end
   rescue ActiveStorage::IntegrityError
     head :unprocessable_entity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  get  "/rails/active_storage/postgresql/:encoded_key/*filename" => "active_storage/postgresql#show", as: :rails_postgresql_service
+  put  "/rails/active_storage/postgresql/:encoded_token" => "active_storage/postgresql#update", as: :update_rails_postgresql_service
+end

--- a/lib/active_storage/service/postgresql_service.rb
+++ b/lib/active_storage/service/postgresql_service.rb
@@ -75,7 +75,7 @@ module ActiveStorage
           purpose: :blob_key }
         )
 
-        generated_url = url_helpers.rails_disk_service_url(verified_key_with_expiration,
+        generated_url = url_helpers.rails_postgresql_service_url(verified_key_with_expiration,
           host: current_host,
           disposition: content_disposition,
           content_type: content_type,
@@ -100,7 +100,7 @@ module ActiveStorage
           purpose: :blob_token }
         )
 
-        generated_url = url_helpers.update_rails_disk_service_url(verified_token_with_expiration, host: current_host)
+        generated_url = url_helpers.update_rails_postgresql_service_url(verified_token_with_expiration, host: current_host)
 
         payload[:url] = generated_url
 

--- a/test/active_storage/postgresql_test.rb
+++ b/test/active_storage/postgresql_test.rb
@@ -59,7 +59,7 @@ class ActiveStorage::Service::PostgreSQLServiceTest < ActiveSupport::TestCase
   end
 
   test "url generation" do
-    assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
+    assert_match(/^https:\/\/example.com\/rails\/active_storage\/postgresql\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
       @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::PostgreSQL::Filename.new("avatar.png"), content_type: "image/png"))
   end
 

--- a/test/active_storage/postgresql_test.rb
+++ b/test/active_storage/postgresql_test.rb
@@ -60,7 +60,7 @@ class ActiveStorage::Service::PostgreSQLServiceTest < ActiveSupport::TestCase
 
   test "url generation" do
     assert_match(/^https:\/\/example.com\/rails\/active_storage\/postgresql\/.*\/avatar\.png\?content_type=image%2Fpng&disposition=inline/,
-      @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::PostgreSQL::Filename.new("avatar.png"), content_type: "image/png"))
+      @service.url(FIXTURE_KEY, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 
   test "headers_for_direct_upload generation" do

--- a/test/controllers/postgresql_controller_test.rb
+++ b/test/controllers/postgresql_controller_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorage::PostgresqlControllerTest < ActionDispatch::IntegrationTest
+  test "showing blob inline" do
+    blob = create_blob(filename: "hello.jpg", content_type: "image/jpg")
+
+    get blob.service_url
+    assert_response :ok
+    assert_equal "inline; filename=\"hello.jpg\"; filename*=UTF-8''hello.jpg", response.headers["Content-Disposition"]
+    assert_equal "image/jpg", response.headers["Content-Type"]
+    assert_equal "Hello world!", response.body
+  end
+
+  test "showing blob as attachment" do
+    blob = create_blob
+    get blob.service_url(disposition: :attachment)
+    assert_response :ok
+    assert_equal "attachment; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", response.headers["Content-Disposition"]
+    assert_equal "text/plain", response.headers["Content-Type"]
+    assert_equal "Hello world!", response.body
+  end
+
+  test "showing blob range" do
+    blob = create_blob
+    get blob.service_url, headers: { "Range" => "bytes=5-9" }
+    assert_response :partial_content
+    assert_equal "attachment; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", response.headers["Content-Disposition"]
+    assert_equal "text/plain", response.headers["Content-Type"]
+    assert_equal " worl", response.body
+  end
+
+  test "showing blob that does not exist" do
+    blob = create_blob
+    blob.delete
+
+    get blob.service_url
+  end
+
+  test "showing blob with invalid key" do
+    get rails_postgresql_service_url(encoded_key: "Invalid key", filename: "hello.txt")
+    assert_response :not_found
+  end
+
+
+  test "directly uploading blob with integrity" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest(data)
+
+    put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain" }
+    assert_response :no_content
+    assert_equal data, blob.download
+  end
+
+  test "directly uploading blob without integrity" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest("bad data")
+
+    put blob.service_url_for_direct_upload, params: data
+    assert_response :unprocessable_entity
+    assert_not blob.service.exist?(blob.key)
+  end
+
+  test "directly uploading blob with mismatched content type" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest(data)
+
+    put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/octet-stream" }
+    assert_response :unprocessable_entity
+    assert_not blob.service.exist?(blob.key)
+  end
+
+  test "directly uploading blob with different but equivalent content type" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload(
+      byte_size: data.size, checksum: Digest::MD5.base64digest(data), content_type: "application/x-gzip")
+
+    put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/x-gzip" }
+    assert_response :no_content
+    assert_equal data, blob.download
+  end
+
+  test "directly uploading blob with mismatched content length" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: Digest::MD5.base64digest(data)
+
+    put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain" }
+    assert_response :unprocessable_entity
+    assert_not blob.service.exist?(blob.key)
+  end
+
+  test "directly uploading blob with invalid token" do
+    put update_rails_postgresql_service_url(encoded_token: "invalid"),
+      params: "Something else entirely!", headers: { "Content-Type" => "text/plain" }
+    assert_response :not_found
+  end
+end

--- a/test/controllers/postgresql_controller_test.rb
+++ b/test/controllers/postgresql_controller_test.rb
@@ -32,6 +32,12 @@ class ActiveStorage::PostgresqlControllerTest < ActionDispatch::IntegrationTest
     assert_equal " worl", response.body
   end
 
+  test "showing blob with empty range" do
+    blob = create_blob
+    get blob.service_url, headers: { "Range" => "bytes=100-" }
+    assert_response 416
+  end
+
   test "showing blob that does not exist" do
     blob = create_blob
     blob.delete

--- a/test/controllers/postgresql_controller_test.rb
+++ b/test/controllers/postgresql_controller_test.rb
@@ -16,6 +16,7 @@ class ActiveStorage::PostgresqlControllerTest < ActionDispatch::IntegrationTest
   test "showing blob as attachment" do
     blob = create_blob
     get blob.service_url(disposition: :attachment)
+
     assert_response :ok
     assert_equal "attachment; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", response.headers["Content-Disposition"]
     assert_equal "text/plain", response.headers["Content-Type"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,25 @@ ActiveSupport::TestCase.setup do
   DatabaseCleaner.start
 end
 
+class ActiveSupport::TestCase
+
+  setup do
+    ActiveStorage::Current.host = "https://example.com"
+  end
+
+  teardown do
+    ActiveStorage::Current.reset
+  end
+
+  def create_blob(data: "Hello world!", filename: "hello.txt", content_type: "text/plain", identify: true)
+    ActiveStorage::Blob.create_after_upload! io: StringIO.new(data), filename: filename, content_type: content_type
+  end
+
+  def create_blob_before_direct_upload(filename: "hello.txt", byte_size:, checksum:, content_type: "text/plain")
+    ActiveStorage::Blob.create_before_direct_upload! filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type
+  end
+end
+
 ActiveSupport::TestCase.teardown do
   ActiveRecord::Base.transaction do
     ActiveRecord::Base.connection.select_values("SELECT oid from pg_largeobject_metadata").each do |oid|


### PR DESCRIPTION
In rails/rails@390097531bd17369f05a23eba58c37b850ac95dd, the `ActiveStorage::DiskController` started to use apis on the `DiskService` that were not part of the standard service interface.

As a result, the `ActiveStorage::DiskController`  is no longer able to service files from the `PostgreSQL` backend.

This PR makes a new dedicated controller for serving PostgreSQL files, and implements support for `Range` heads which were added to the  `ActiveStorage::DiskController`.

This makes `active_storage-postgresql` compatible with Rails 5.2.2.

Fixes #5 