### PR TITLE
Require the File model in the controller

### DIFF
--- a/app/controllers/active_storage/postgresql_controller.rb
+++ b/app/controllers/active_storage/postgresql_controller.rb
@@ -5,6 +5,8 @@
 # Always go through the BlobsController, or your own authenticated controller, rather than directly
 # to the service url.
 
+require 'active_storage/postgresql/file'
+
 class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
 
   skip_forgery_protection


### PR DESCRIPTION
If one of your first web requests is for an Active Storage blob, `ActiveStorage::PostgreSQL::File` is not guaranteed to be defined.