### PR TITLE
Fix "wrong number of arguments" in Ruby 3

### DIFF
--- a/lib/active_storage/service/postgresql_service.rb
+++ b/lib/active_storage/service/postgresql_service.rb
@@ -71,8 +71,8 @@ module ActiveStorage
             disposition: content_disposition,
             content_type: content_type
           },
-          { expires_in: expires_in,
-          purpose: :blob_key }
+          expires_in: expires_in,
+          purpose: :blob_key
         )
 
         generated_url = url_helpers.rails_postgresql_service_url(verified_key_with_expiration,
@@ -96,8 +96,8 @@ module ActiveStorage
             content_length: content_length,
             checksum: checksum
           },
-          { expires_in: expires_in,
-          purpose: :blob_token }
+          expires_in: expires_in,
+          purpose: :blob_token
         )
 
         generated_url = url_helpers.update_rails_postgresql_service_url(verified_token_with_expiration, host: current_host)


### PR DESCRIPTION
hashes are no longer passed as keyword arguments