### PR TITLE
Fix CVE-2018-16477

### DIFF
--- a/app/controllers/active_storage/postgresql_controller.rb
+++ b/app/controllers/active_storage/postgresql_controller.rb
@@ -11,8 +11,8 @@ class ActiveStorage::PostgresqlController < ActiveStorage::BaseController
 
   def show
     if key = decode_verified_key
-      response.headers["Content-Type"] = params[:content_type] || DEFAULT_SEND_FILE_TYPE
-      response.headers["Content-Disposition"] = params[:disposition] || DEFAULT_SEND_FILE_DISPOSITION
+      response.headers["Content-Type"] = key[:content_type] || DEFAULT_SEND_FILE_TYPE
+      response.headers["Content-Disposition"] = key[:disposition] || DEFAULT_SEND_FILE_DISPOSITION
       size = ActiveStorage::PostgreSQL::File.open(key[:key], &:size)
 
       ranges = Rack::Utils.get_byte_ranges(request.get_header('HTTP_RANGE'), size)

--- a/test/controllers/postgresql_controller_test.rb
+++ b/test/controllers/postgresql_controller_test.rb
@@ -51,6 +51,22 @@ class ActiveStorage::PostgresqlControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "not allowing to set disposition from params" do
+    blob = create_blob(filename: "hello.jpg", content_type: "image/jpeg")
+
+    get blob.send(url_method), params: { disposition: :attachment }
+    assert_response :ok
+    assert_equal "inline; filename=\"hello.jpg\"; filename*=UTF-8''hello.jpg", response.headers["Content-Disposition"]
+  end
+
+  test "not allowing to set content-type from params" do
+    blob = create_blob(filename: "hello.jpg", content_type: "image/jpeg")
+
+    get blob.send(url_method), params: { content_type: 'text/html' }
+    assert_response :ok
+    assert_equal "image/jpeg", response.headers["Content-Type"]
+  end
+
 
   test "directly uploading blob with integrity" do
     data = "Something else entirely!"


### PR DESCRIPTION
Hi there :)

Just found out that CVE-2018-16477 is still reproducible, which is pretty nuts, considering that the files with this storage option are always served from the same domain as the app itself.
So an attacker can upload a malicious HTML using direct-upload (e.g as an ActionText attachment) and then serve it from the app's domain with content-disposition inline.

There was a fix applied in https://github.com/lsylvester/active_storage-postgresql/commit/fd56cf2d5f27a31b7f0dde69d0d9487cdba50bc2  which resolved the exploit based on the  https://github.com/rails/rails/commit/54ed6ad8d7468dc3a0b690e629c7c18497552eb8

Hovewer this commit https://github.com/lsylvester/active_storage-postgresql/pull/6/commits/f3ad1e73a30cc462a2bbabfcb9799a8813978674 introduced custom `ActiveStorage::PostgresqlController#show` which doesn’t use the content-type and disposition encoded in the `key`, bringing the exploit back.