### PR TITLE
Inherit  from ApplicationRecord when on Rails 7

### DIFF
--- a/lib/active_storage/postgresql/file.rb
+++ b/lib/active_storage/postgresql/file.rb
@@ -1,4 +1,4 @@
-class ActiveStorage::PostgreSQL::File < ActiveRecord::Base
+class ActiveStorage::PostgreSQL::File < (defined?(Rails) && Rails.gem_version >= Gem::Version.new("7.0") ? ApplicationRecord : ActiveRecord::Base)
   self.table_name = "active_storage_postgresql_files"
 
   attribute :oid, :integer, default: ->{ connection.raw_connection.lo_creat }


### PR DESCRIPTION
It appears that bindings have changed when on Rails 7 and inheriting from ActiveRecord::Base results in trying to make connection through the activerecord adapter for File which fails with ActiveRecord::ConnectionNotEstablished. Given ApplicationRecord is suppose to be the new parent class anyways, updating the logic accordingly.

```
Requiring all gems to prepare for compiling... You don't have dalli installed in your application. Please add it to your Gemfile and run bundle install
bundler: failed to load command: tapioca (/Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/bin/tapioca)
/Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/gems/activerecord-7.0.8.3/lib/active_record/connection_handling.rb:309:in `connection_pool': ActiveRecord::ConnectionNotEstablished (ActiveRecord::ConnectionNotEstablished)
	from /Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/gems/activerecord-7.0.8.3/lib/active_record/connection_handling.rb:305:in `connection_db_config'
	from /Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/gems/activerecord-7.0.8.3/lib/active_record/type.rb:50:in `adapter_name_from'
	from /Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/gems/activerecord-7.0.8.3/lib/active_record/attributes.rb:216:in `attribute'
	from /Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/gems/active_storage-postgresql-0.3.1/lib/active_storage/postgresql/file.rb:4:in `<class:File>'
	from /Users/shayon/src/tines/backend/vendor/bundle/ruby/3.3.0/gems/active_storage-postgresql-0.3.1/lib/active_storage/postgresql/file.rb:1:in `<main>'
	from /Users/shayon/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/shayon/.rbenv/versions/3.3.1/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'

```

Open to any feedback/suggestions here, thank you